### PR TITLE
Track upstream to solve CVE-2021-3803

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# This is a forked version of the original [badge-up npm package](https://www.npmjs.com/package/badge-up)
+
+The only changes applied to the original npm package are:
+
+- updated npm dependencies (to fix some known vulnerabilities detected by npm audit)
+- adapt sources to the changes introduced in the new `svgo` library
+
+------
+
 # badge-up
 
 [![npm](https://img.shields.io/npm/v/badge-up.svg?maxAge=2592000)](https://www.npmjs.com/package/badge-up)

--- a/index.js
+++ b/index.js
@@ -38,9 +38,9 @@ module.exports = function badge (field1, field2, color, callback) {
         };
 
     // Run the SVG through SVGO.
-    svgo.optimize(template(data), function (object) {
+    svgo.optimize(template(data)).then(function (object) {
         callback(null, object.data);
-    });
+    }).catch(callback);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "badge-up",
+  "name": "@rpl/badge-up",
   "version": "2.2.0",
-  "description": "A module that produces hot badges without the need of Cairo",
+  "description": "A module that produces hot badges without the need of Cairo (forked from the original badge-up package to update vulnerable npm deps)",
   "main": "index.js",
   "scripts": {
     "lint": "jshint *.js test/*.js",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:yahoo/badge-up.git"
+    "url": "git@github.com:rpl/badge-up.git"
   },
   "bugs": "https://github.com/yahoo/badge-up/issues",
   "keywords": [
@@ -29,14 +29,14 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "coveralls": "^2.11.15",
-    "jenkins-mocha": "^4.1.0",
+    "coveralls": "^3.0.2",
+    "jenkins-mocha": "^6.0.0",
     "jshint": "^2.9.2",
     "sinon": "^1.17.7"
   },
   "dependencies": {
     "css-color-names": "~0.0.3",
     "dot": "^1.1.1",
-    "svgo": "^0.7.2"
+    "svgo": "^1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,16 +43,16 @@
     }
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "coveralls": "^3.0.11",
-    "eslint": "^6.8.0",
-    "mocha": "^7.1.1",
-    "nyc": "^15.0.0",
-    "sinon": "^9.0.1"
+    "chai": "^4.3.4",
+    "coveralls": "^3.1.0",
+    "eslint": "^7.29.0",
+    "mocha": "^9.0.1",
+    "nyc": "^15.1.0",
+    "sinon": "^11.1.1"
   },
   "dependencies": {
     "css-color-names": "~1.0.1",
     "dot": "^1.1.3",
-    "svgo": "^1.3.2"
+    "svgo": "^2.3.1"
   }
 }

--- a/v2.js
+++ b/v2.js
@@ -99,9 +99,9 @@ function sectionsToData(sections) {
 
 module.exports = function badge_v2(sections, callback) {
     var raw = TEMPLATE(sectionsToData(sections));
-    svgo.optimize(raw, function(optimized) {
+    svgo.optimize(raw).then(function(optimized) {
         callback(undefined, optimized.data);
-    });
+    }).catch(callback);
 };
 
 


### PR DESCRIPTION
Pull https://github.com/yahoo/badge-up/pull/21 to upgrade svgo to upgrade transitive dependency nth-check to v2.0.1. This fixes CVE-2021-3803.

This is a step towards solving https://github.com/rpl/flow-coverage-report/issues/206.