### PR TITLE
fix: Updated svgo dependency to v2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   "dependencies": {
     "css-color-names": "~1.0.1",
     "dot": "^1.1.3",
-    "svgo": "^1.3.2"
+    "svgo": "2.6.0"
   }
 }

--- a/utils.js
+++ b/utils.js
@@ -14,7 +14,18 @@ var LETTER_WIDTH = [
         8,8,8,8,8,7,7,7,6,6,6,6,6,6,9,5,6,6,6,6,3,3,3,3,6,6,6,6,6,6,6,6,7,6,6,6,
         6,5,6
     ];
-
+/**
+ * Replace numeric entity codes with the related entity code name
+ * for the "<" and "&" characters. Prevent svgo "Unencoded ..." errors,
+ * see https://github.com/svg/svgo/issues/1498.
+ * @method replaceNumericEntities
+ * @param  {String}  string Input string
+ * @return {String}         Fixed string
+ */
+module.exports.fixupNumericEntities = function replaceNumericEntitities(string) {
+    return string.replace(/&#(x3c|60);/gi, '&lt;')
+                 .replace(/&#(x26|38);/gi, '&amp;');
+} 
 
 /**
  * Escape the string so that it doesn't break xml


### PR DESCRIPTION
This PR includes a set of changes to update the svgo dependency to v.2.6.0 along with updating the fork to the tip of the upstream main branch (and keeping the diff between this fork and the upstream version as small and clean as possible).

This is meant to cover and supersede #1

TODO:
- [x] try the new version @rpl/badge package with flow-coverage-reporter to confirm that it does work as expected
- [x] tag a new release and publish it on npm
- [ ] open the related flow-coverage-reporter PR to update the dependency (and double-check if that's enough to clear all issues currently reported by `npm audit`)   